### PR TITLE
Follow HTTP redirects

### DIFF
--- a/src/firebaseLib.php
+++ b/src/firebaseLib.php
@@ -197,6 +197,7 @@ class FirebaseLib implements FirebaseInterface
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $mode);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         return $ch;
     }
 


### PR DESCRIPTION
The Nest API requires you to follow redirects, and it's very likely that they are not the only ones.

Please add support for following redirects :)